### PR TITLE
Improve dark mode contrast

### DIFF
--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -22,7 +22,8 @@ abstract class AppColors {
   static const Color backgroundDark = Color(0xFF111827); // Very Dark Blue/Gray
   static const Color surfaceDark = Color(0xFF1F2937); // Dark Gray
   static const Color onSurfaceDark = Color(0xFFF3F4F6); // Light Gray
-  static const Color onSurfaceVariantDark = Color(0xFF9CA3AF); // Medium-Light Gray
+  // Lightened for better readability in Dark Mode
+  static const Color onSurfaceVariantDark = Color(0xFFC7C7CC);
 
   // Semantic Colors
   static const Color error = Color(0xFFEF4444); // Red

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -22,7 +22,8 @@ abstract class AppTheme {
   static const Color _backgroundDark = Color(0xFF000000);
   static const Color _surfaceDark = Color(0xFF1C1C1E);
   static const Color _onSurfaceDark = Color(0xFFE5E5EA);
-  static const Color _onSurfaceVariantDark = Color(0xFF8A8A8E);
+  // Increased contrast for dark mode readability
+  static const Color _onSurfaceVariantDark = Color(0xFFC7C7CC);
 
   static final _cardShapeLight = RoundedRectangleBorder(
     borderRadius: const BorderRadius.all(Radius.circular(20.0)),


### PR DESCRIPTION
## Summary
- update dark theme text color for better readability

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685167fad1e48324b15360f5a2d3b56c