### PR TITLE
Localize UI strings

### DIFF
--- a/assets/l10n/de.json
+++ b/assets/l10n/de.json
@@ -8,12 +8,10 @@
   "close": "Schließen",
   "error_occurred": "Ein Fehler ist aufgetreten",
   "loading": "Lädt...",
-
   "bottom_nav_subscriptions": "Abos",
   "bottom_nav_statistics": "Statistik",
   "bottom_nav_settings": "Einstellungen",
   "bottom_nav_about": "Über",
-  
   "home_my_subscriptions": "Meine Abos",
   "home_search_subscriptions_hint": "Abos suchen...",
   "home_search_tooltip": "Suchen",
@@ -35,7 +33,6 @@
   "filter_sheet_categories": "Kategorien",
   "filter_sheet_billing_cycles": "Zahlungszyklen",
   "filter_sheet_apply": "Filter anwenden",
-
   "sort_option_nameAsc": "Name (A-Z)",
   "sort_option_nameDesc": "Name (Z-A)",
   "sort_option_priceAsc": "Preis (Gering-Hoch)",
@@ -43,7 +40,6 @@
   "sort_option_nextBillingDateAsc": "Nächste Zahlung (Früheste)",
   "sort_option_nextBillingDateDesc": "Nächste Zahlung (Späteste)",
   "sort_option_category": "Kategorie",
-  
   "subscription_card_trial_badge": "PROBE",
   "subscription_card_days_until_label_prefix": "in ",
   "subscription_card_days_until_label_suffix": "Tagen",
@@ -61,7 +57,6 @@
   "subscription_delete_confirm_message": "Möchtest du \"{name}\" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
   "subscription_deleted_snackbar": "\"{name}\" gelöscht.",
   "subscription_undo_snackbar_action": "Rückgängig",
-  
   "add_edit_screen_title_add": "Abo hinzufügen",
   "add_edit_screen_title_edit": "Abo bearbeiten",
   "add_edit_screen_save_tooltip": "Abo speichern",
@@ -93,21 +88,18 @@
   "add_edit_screen_button_add": "Abo hinzufügen",
   "add_edit_screen_button_update": "Abo aktualisieren",
   "add_edit_screen_snackbar_invalid_custom_cycle": "Ungültige Zyklustage. Bitte korrigieren.",
-
   "billing_cycle_weekly": "Wöchentlich",
   "billing_cycle_monthly": "Monatlich",
   "billing_cycle_quarterly": "Vierteljährlich",
   "billing_cycle_biAnnual": "Halbjährlich",
   "billing_cycle_yearly": "Jährlich",
   "billing_cycle_custom": "Benutzerdefiniert (Tage)",
-  
   "billing_cycle_short_weekly": "Wo",
   "billing_cycle_short_monthly": "Mo",
   "billing_cycle_short_quarterly": "Qt",
   "billing_cycle_short_biAnnual": "6Mo",
   "billing_cycle_short_yearly": "Jr",
   "billing_cycle_short_custom": "Ind",
-
   "category_streaming": "Streaming",
   "category_software": "Software",
   "category_gaming": "Gaming",
@@ -118,7 +110,6 @@
   "category_utilities": "Haushalt",
   "category_education": "Bildung",
   "category_other": "Sonstiges",
-
   "settings_title": "Einstellungen",
   "settings_section_appearance": "Erscheinungsbild",
   "settings_theme_title": "Design",
@@ -137,7 +128,6 @@
   "settings_about_app_title": "Über AboApp",
   "settings_app_version": "Version {version}",
   "settings_app_description_long": "Abo-Verwaltung leicht gemacht, damit du deine wiederkehrenden Kosten im Griff hast.",
-
   "stats_title": "Statistiken",
   "stats_year_selector_tooltip": "Jahr auswählen",
   "stats_empty_title": "Noch keine Statistiken",
@@ -158,5 +148,21 @@
   "stats_top_subscriptions_empty_message": "Keine Abos in der Top-Liste anzuzeigen.",
   "stats_per_month_label": "pro Monat",
   "stats_subscription_abbrev_single": "Abo",
-  "stats_subscription_abbrev_multiple": "Abos"
+  "stats_subscription_abbrev_multiple": "Abos",
+  "bottom_nav_profile": "Profil",
+  "home_filter_sort_tooltip": "Filtern & Sortieren",
+  "home_no_subscriptions_found_title": "Keine Abos gefunden",
+  "settings_section_salary": "Gehaltsinformationen",
+  "settings_section_advanced": "Erweitert",
+  "settings_rerun_onboarding_title": "Willkommensbildschirm erneut anzeigen?",
+  "settings_rerun_onboarding_message": "Der Willkommensbildschirm wird beim naechsten Start der App erneut angezeigt. Deine bestehenden Abos und Einstellungen bleiben erhalten.",
+  "settings_rerun_onboarding_subtitle": "Zeigt die Einfuehrung erneut",
+  "confirm": "Bestätigen",
+  "settings_salary_title": "Dein Gehalt",
+  "settings_salary_description": "Optional, hilft persönliche Ausgabenstatistiken zu erstellen. Die Daten werden nur auf deinem Gerät gespeichert.",
+  "settings_salary_amount_label": "Gehaltsbetrag",
+  "settings_salary_13th_checkbox": "Ich erhalte einen 13. Monatslohn",
+  "onboarding_salary_optional_title": "Optional: Gehaltsinformationen",
+  "onboarding_salary_optional_desc": "Gib dein Gehalt ein, um zu sehen, welcher Anteil für Abos ausgegeben wird. Diese Angabe ist optional und wird nur auf deinem Gerät gespeichert.",
+  "page_not_found_title": "Seite nicht gefunden"
 }

--- a/assets/l10n/en.json
+++ b/assets/l10n/en.json
@@ -8,12 +8,10 @@
   "close": "Close",
   "error_occurred": "An Error Occurred",
   "loading": "Loading...",
-
   "bottom_nav_subscriptions": "Subscriptions",
   "bottom_nav_statistics": "Statistics",
   "bottom_nav_settings": "Settings",
   "bottom_nav_about": "About",
-
   "home_my_subscriptions": "My Subscriptions",
   "home_search_subscriptions_hint": "Search subscriptions...",
   "home_search_tooltip": "Search",
@@ -35,7 +33,6 @@
   "filter_sheet_categories": "Categories",
   "filter_sheet_billing_cycles": "Billing Cycles",
   "filter_sheet_apply": "Apply Filters",
-  
   "sort_option_nameAsc": "Name (A-Z)",
   "sort_option_nameDesc": "Name (Z-A)",
   "sort_option_priceAsc": "Price (Low-High)",
@@ -43,7 +40,6 @@
   "sort_option_nextBillingDateAsc": "Next Billing (Soonest)",
   "sort_option_nextBillingDateDesc": "Next Billing (Latest)",
   "sort_option_category": "Category",
-
   "subscription_card_trial_badge": "TRIAL",
   "subscription_card_days_until_label_prefix": "",
   "subscription_card_days_until_label_suffix": "days",
@@ -61,7 +57,6 @@
   "subscription_delete_confirm_message": "Are you sure you want to delete \"{name}\"? This action cannot be undone.",
   "subscription_deleted_snackbar": "\"{name}\" deleted.",
   "subscription_undo_snackbar_action": "Undo",
-
   "add_edit_screen_title_add": "Add Subscription",
   "add_edit_screen_title_edit": "Edit Subscription",
   "add_edit_screen_save_tooltip": "Save Subscription",
@@ -93,21 +88,18 @@
   "add_edit_screen_button_add": "Add Subscription",
   "add_edit_screen_button_update": "Update Subscription",
   "add_edit_screen_snackbar_invalid_custom_cycle": "Invalid custom cycle days. Please correct.",
-
   "billing_cycle_weekly": "Weekly",
   "billing_cycle_monthly": "Monthly",
   "billing_cycle_quarterly": "Quarterly",
   "billing_cycle_biAnnual": "Every 6 Months",
   "billing_cycle_yearly": "Yearly",
   "billing_cycle_custom": "Custom (Days)",
-  
   "billing_cycle_short_weekly": "wk",
   "billing_cycle_short_monthly": "mo",
   "billing_cycle_short_quarterly": "qtr",
   "billing_cycle_short_biAnnual": "6mo",
   "billing_cycle_short_yearly": "yr",
   "billing_cycle_short_custom": "cust",
-
   "category_streaming": "Streaming",
   "category_software": "Software",
   "category_gaming": "Gaming",
@@ -118,7 +110,6 @@
   "category_utilities": "Utilities",
   "category_education": "Education",
   "category_other": "Other",
-  
   "settings_title": "Settings",
   "settings_section_appearance": "Appearance",
   "settings_theme_title": "Theme",
@@ -137,7 +128,6 @@
   "settings_about_app_title": "About AboApp",
   "settings_app_version": "Version {version}",
   "settings_app_description_long": "Subscription management made easy, keeping you in control of your recurring expenses.",
-
   "stats_title": "Statistics",
   "stats_year_selector_tooltip": "Select Year",
   "stats_empty_title": "No Statistics Yet",
@@ -169,6 +159,21 @@
   "onboarding_page4_desc": "Get timely reminders before your subscriptions are due.",
   "onboarding_skip_button": "Skip",
   "onboarding_next_button": "Next",
-  "onboarding_get_started_button": "Get Started"
-  
+  "onboarding_get_started_button": "Get Started",
+  "bottom_nav_profile": "Profile",
+  "home_filter_sort_tooltip": "Filter & Sort",
+  "home_no_subscriptions_found_title": "No Subscriptions Found",
+  "settings_section_salary": "Salary Insights",
+  "settings_section_advanced": "Advanced",
+  "settings_rerun_onboarding_title": "Rerun Welcome Screen?",
+  "settings_rerun_onboarding_message": "This will show the welcome screen the next time you open the app. Your existing subscriptions and settings will not be deleted.",
+  "settings_rerun_onboarding_subtitle": "Shows the initial setup screens again",
+  "confirm": "Confirm",
+  "settings_salary_title": "Your Salary",
+  "settings_salary_description": "This is optional and helps generate personal spending statistics. The data is stored only on your device.",
+  "settings_salary_amount_label": "Salary Amount",
+  "settings_salary_13th_checkbox": "I receive a 13th salary",
+  "onboarding_salary_optional_title": "Optional: Salary Insights",
+  "onboarding_salary_optional_desc": "Enter your salary to see what percentage of it goes to subscriptions. This is optional and stored only on your device.",
+  "page_not_found_title": "Page Not Found"
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:aboapp/core/localization/app_localizations.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class AboApp extends StatelessWidget {
   const AboApp({super.key});
@@ -34,7 +35,7 @@ class AboApp extends StatelessWidget {
       child: BlocBuilder<SettingsCubit, SettingsState>(
         builder: (context, settingsState) {
           return MaterialApp.router(
-            title: 'AboApp V4',
+            title: context.l10n.translate('app_title'),
             debugShowCheckedModeBanner: false,
             // VEREINFACHT: Wir verwenden jetzt immer das AppTheme.
             theme: AppTheme.lightTheme,

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 abstract class AppRoutes {
   static const String onboarding = '/onboarding';
@@ -78,7 +79,9 @@ class AppRouter {
         ),
       ],
       errorBuilder: (context, state) => Scaffold(
-        appBar: AppBar(title: const Text('Page Not Found')),
+        appBar: AppBar(
+          title: Text(context.l10n.translate('page_not_found_title')),
+        ),
         body: Center(child: Text('Error: \n${state.error}')),
       ),
     );

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:aboapp/core/di/injection.dart';
 import 'package:aboapp/core/utils/haptic_feedback.dart' as app_haptics;
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class OnboardingScreen extends StatefulWidget {
   const OnboardingScreen({super.key});
@@ -44,29 +45,27 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     super.didChangeDependencies();
     _onboardingPages = [
       _OnboardingScreenData(
-        titleKey: 'Welcome to AboApp',
-        descriptionKey: 'Easily manage all your subscriptions in one place.',
+        titleKey: 'onboarding_page1_title',
+        descriptionKey: 'onboarding_page1_desc',
         iconData: Icons.account_balance_wallet_outlined,
         iconColor: Theme.of(context).colorScheme.primary,
       ),
       _OnboardingScreenData(
-        titleKey: 'Add Subscriptions',
-        descriptionKey:
-            'Track your recurring payments and never miss a due date.',
+        titleKey: 'onboarding_page2_title',
+        descriptionKey: 'onboarding_page2_desc',
         iconData: Icons.add_circle_outline_rounded,
         iconColor: Colors.green.shade600,
       ),
       _OnboardingScreenData(
-        titleKey: 'Salary Insights',
-        descriptionKey:
-            'Enter your salary to see how much you spend on subscriptions.',
+        titleKey: 'onboarding_salary_optional_title',
+        descriptionKey: 'onboarding_salary_optional_desc',
         iconData: Icons.insights_rounded,
         iconColor: Colors.blue.shade600,
         customContent: SalaryOnboardingPage(key: _salaryPageKey),
       ),
       _OnboardingScreenData(
-        titleKey: 'Get Notified',
-        descriptionKey: 'Receive reminders before your next billing date.',
+        titleKey: 'onboarding_page4_title',
+        descriptionKey: 'onboarding_page4_desc',
         iconData: Icons.notifications_active_outlined,
         iconColor: Colors.purple.shade600,
       ),
@@ -110,7 +109,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                 padding: const EdgeInsets.only(top: 8.0, right: 16.0),
                 child: TextButton(
                   onPressed: _completeOnboarding,
-                  child: Text(isLastPage ? 'Done' : 'Skip'),
+                  child: Text(isLastPage
+                      ? context.l10n.translate('onboarding_get_started_button')
+                      : context.l10n.translate('onboarding_skip_button')),
                 ),
               ),
             ),
@@ -133,8 +134,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                   }
                   return SingleChildScrollView(
                     child: OnboardingPageContentWidget(
-                      title: pageData.titleKey,
-                      description: pageData.descriptionKey,
+                      title: context.l10n.translate(pageData.titleKey),
+                      description: context.l10n.translate(pageData.descriptionKey),
                       iconData: pageData.iconData,
                       iconColor: pageData.iconColor,
                     ),
@@ -178,7 +179,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
                     }
                   },
                   child: Text(
-                    isLastPage ? 'Get Started' : 'Next',
+                    isLastPage
+                        ? context.l10n.translate('onboarding_get_started_button')
+                        : context.l10n.translate('onboarding_next_button'),
                   ),
                 ),
               ),

--- a/lib/features/onboarding/presentation/widgets/salary_onboarding_page.dart
+++ b/lib/features/onboarding/presentation/widgets/salary_onboarding_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:aboapp/core/utils/haptic_feedback.dart' as app_haptics;
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class SalaryOnboardingPage extends StatefulWidget {
   const SalaryOnboardingPage({super.key});
@@ -52,14 +53,14 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
             Icon(Icons.insights_rounded, size: 80, color: Colors.blue.shade600),
             const SizedBox(height: 24),
             Text(
-              "Optional: Salary Insights",
+              context.l10n.translate('onboarding_salary_optional_title'),
               textAlign: TextAlign.center,
               style: theme.textTheme.headlineSmall
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
             Text(
-              "Enter your salary to see what percentage of it goes to subscriptions. This is optional and stored only on your device.",
+              context.l10n.translate('onboarding_salary_optional_desc'),
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyLarge
                   ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
@@ -68,7 +69,8 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
             TextFormField(
               controller: _salaryController,
               decoration: InputDecoration(
-                labelText: "Salary Amount",
+                labelText:
+                    context.l10n.translate('settings_salary_amount_label'),
                 hintText: "e.g., 5000",
                 prefixIcon: const Icon(Icons.attach_money_rounded),
               ),
@@ -79,14 +81,14 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
             ),
             const SizedBox(height: 16),
             SegmentedButton<SalaryCycle>(
-              segments: const [
+              segments: [
                 ButtonSegment(
                     value: SalaryCycle.monthly,
-                    label: Text("Monthly"),
+                    label: Text(context.l10n.translate('billing_cycle_monthly')),
                     icon: Icon(Icons.calendar_view_month)),
                 ButtonSegment(
                     value: SalaryCycle.yearly,
-                    label: Text("Yearly"),
+                    label: Text(context.l10n.translate('billing_cycle_yearly')),
                     icon: Icon(Icons.calendar_today)),
               ],
               selected: {_salaryCycle},
@@ -105,7 +107,8 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
             const SizedBox(height: 8),
             if (_salaryCycle == SalaryCycle.monthly)
               SwitchListTile.adaptive(
-                title: const Text("I receive a 13th salary"),
+                title:
+                    Text(context.l10n.translate('settings_salary_13th_checkbox')),
                 value: _hasThirteenthSalary,
                 onChanged: (value) {
                   app_haptics.HapticFeedback.lightImpact();

--- a/lib/features/settings/presentation/cubit/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/cubit/screens/settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -60,17 +61,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        title: const Text('Rerun Welcome Screen?'),
-        content: const Text(
-            'This will show the welcome screen the next time you open the app. Your existing subscriptions and settings will not be deleted.'),
+        title: Text(context.l10n.translate('settings_rerun_onboarding_title')),
+        content: Text(
+            context.l10n.translate('settings_rerun_onboarding_message')),
         actions: <Widget>[
           TextButton(
-            child: const Text('Cancel'),
+            child: Text(context.l10n.translate('cancel')),
             onPressed: () => Navigator.of(dialogContext).pop(),
           ),
           TextButton(
-            child: Text('Confirm',
-                style: TextStyle(color: Theme.of(context).colorScheme.primary)),
+            child: Text(
+              context.l10n.translate('confirm'),
+              style: TextStyle(color: Theme.of(context).colorScheme.primary),
+            ),
             onPressed: () async {
               Navigator.of(dialogContext).pop(); // Close the dialog first
               final prefs = getIt<SharedPreferences>();
@@ -89,17 +92,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
   String _getThemeModeDisplayName(BuildContext context, ThemeMode themeMode) {
     switch (themeMode) {
       case ThemeMode.system:
-        return 'System Default';
+        return context.l10n.translate('settings_theme_system');
       case ThemeMode.light:
-        return 'Light';
+        return context.l10n.translate('settings_theme_light');
       case ThemeMode.dark:
-        return 'Dark';
+        return context.l10n.translate('settings_theme_dark');
     }
   }
 
   String _getLocaleDisplayName(BuildContext context, Locale locale) {
-    if (locale.languageCode == 'en') return 'English';
-    if (locale.languageCode == 'de') return 'Deutsch (German)';
+    if (locale.languageCode == 'en')
+      return context.l10n.translate('settings_language_english');
+    if (locale.languageCode == 'de')
+      return context.l10n.translate('settings_language_german');
     return locale.toLanguageTag();
   }
 
@@ -121,7 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('Settings'),
+          title: Text(context.l10n.translate('settings_title')),
         ),
         body: BlocBuilder<SettingsCubit, SettingsState>(
           builder: (context, state) {
@@ -136,19 +141,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
             return ListView(
               padding: const EdgeInsets.all(16.0),
               children: <Widget>[
-                _buildSectionHeader(context, 'Appearance'),
+                _buildSectionHeader(context, context.l10n.translate('settings_section_appearance')),
                 _buildAppearanceSection(context, state),
                 const Divider(height: 32),
-                _buildSectionHeader(context, 'Regional'),
+                _buildSectionHeader(context, context.l10n.translate('settings_section_regional')),
                 _buildRegionalSection(context, state),
                 const Divider(height: 32),
-                _buildSectionHeader(context, 'Salary Insights'),
+                _buildSectionHeader(context, context.l10n.translate('settings_section_salary')),
                 _buildSalarySection(context, state),
                 const Divider(height: 32),
-                _buildSectionHeader(context, 'Advanced'),
+                _buildSectionHeader(context, context.l10n.translate('settings_section_advanced')),
                 _buildAdvancedSection(context),
                 const Divider(height: 32),
-                _buildSectionHeader(context, 'About'),
+                _buildSectionHeader(context, context.l10n.translate('settings_section_about')),
                 _buildAboutSection(context),
               ],
             );
@@ -162,7 +167,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Card(
       child: ListTile(
         leading: const Icon(Icons.brightness_6_rounded),
-        title: const Text('Theme'),
+        title: Text(context.l10n.translate('settings_theme_title')),
         subtitle: Text(_getThemeModeDisplayName(context, state.themeMode)),
         onTap: () => _showThemeModeDialog(context, state.themeMode),
       ),
@@ -175,14 +180,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
         children: [
           ListTile(
             leading: const Icon(Icons.language_rounded),
-            title: const Text('Language'),
+            title: Text(context.l10n.translate('settings_language_title')),
             subtitle: Text(_getLocaleDisplayName(context, state.locale)),
             onTap: () => _showLocaleDialog(context, state.locale),
           ),
           const Divider(height: 1, indent: 16, endIndent: 16),
           ListTile(
             leading: const Icon(Icons.attach_money_rounded),
-            title: const Text('Currency'),
+            title: Text(context.l10n.translate('settings_currency_title')),
             subtitle: Text(
                 _supportedCurrencies[state.currencyCode] ?? state.currencyCode),
             onTap: () => _showCurrencyDialog(context, state.currencyCode),
@@ -204,12 +209,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              "Your Salary",
+              context.l10n.translate('settings_salary_title'),
               style: theme.textTheme.titleMedium,
             ),
             const SizedBox(height: 4),
             Text(
-              "This is optional and helps generate personal spending statistics. The data is stored only on your device.",
+              context.l10n.translate('settings_salary_description'),
               style: theme.textTheme.bodySmall
                   ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             ),
@@ -217,7 +222,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             TextFormField(
               controller: _salaryController,
               decoration: InputDecoration(
-                labelText: "Salary Amount",
+                labelText: context.l10n.translate('settings_salary_amount_label'),
                 prefixText: "$currencySymbol ",
               ),
               keyboardType:
@@ -229,10 +234,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             const SizedBox(height: 16),
             SegmentedButton<SalaryCycle>(
-              segments: const [
+              segments: [
                 ButtonSegment(
-                    value: SalaryCycle.monthly, label: Text("Monthly")),
-                ButtonSegment(value: SalaryCycle.yearly, label: Text("Yearly")),
+                    value: SalaryCycle.monthly,
+                    label: Text(context.l10n.translate('billing_cycle_monthly'))),
+                ButtonSegment(
+                    value: SalaryCycle.yearly,
+                    label: Text(context.l10n.translate('billing_cycle_yearly'))),
               ],
               selected: {_salaryCycle ?? SalaryCycle.monthly},
               onSelectionChanged: (newSelection) {
@@ -242,7 +250,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
             if (_salaryCycle == SalaryCycle.monthly)
               SwitchListTile.adaptive(
-                title: const Text("I receive a 13th salary"),
+                title: Text(context.l10n.translate('settings_salary_13th_checkbox')),
                 value: _hasThirteenthSalary ?? false,
                 onChanged: (value) {
                   setState(() => _hasThirteenthSalary = value);
@@ -263,9 +271,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
       child: ListTile(
         leading: Icon(Icons.replay_circle_filled_rounded,
             color: theme.colorScheme.error),
-        title: Text('Rerun Welcome Screen',
+        title: Text(
+            context.l10n.translate('settings_rerun_onboarding_title'),
             style: TextStyle(color: theme.colorScheme.onErrorContainer)),
-        subtitle: Text('Shows the initial setup screens again',
+        subtitle: Text(
+            context.l10n.translate('settings_rerun_onboarding_subtitle'),
             style: TextStyle(
                 color: theme.colorScheme.onErrorContainer.withAlpha(204))), // ~80% opacity
         onTap: _showRerunOnboardingDialog,
@@ -277,19 +287,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Card(
       child: ListTile(
         leading: const Icon(Icons.info_outline_rounded),
-        title: const Text('About AboApp'),
-        subtitle: const Text('Version 4.0.0'),
+        title: Text(context.l10n.translate('settings_about_app_title')),
+        subtitle:
+            Text(context.l10n.translate('settings_app_version', args: {'version': '4.0.0'})),
         onTap: () {
           showDialog(
             context: context,
             builder: (ctx) => AlertDialog(
-              title: const Text('About AboApp'),
-              content: const Text(
-                  'Subscription management made easy.\nVersion 4.0.0'),
+              title: Text(context.l10n.translate('settings_about_app_title')),
+              content: Text(
+                '${context.l10n.translate('settings_app_description_long')}\n${context.l10n.translate('settings_app_version', args: {'version': '4.0.0'})}',
+              ),
               actions: [
                 TextButton(
                   onPressed: () => Navigator.of(ctx).pop(),
-                  child: const Text('Close'),
+                  child: Text(context.l10n.translate('close')),
                 )
               ],
             ),
@@ -318,7 +330,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Select Theme'),
+        title: Text(context.l10n.translate('settings_dialog_select_theme_title')),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: ThemeMode.values.map((themeMode) {
@@ -344,7 +356,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Select Language'),
+        title: Text(context.l10n.translate('settings_dialog_select_language_title')),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: supportedLocales.map((locale) {
@@ -369,7 +381,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Select Currency'),
+        title: Text(context.l10n.translate('settings_dialog_select_currency_title')),
         content: SizedBox(
           width: double.maxFinite,
           child: ListView(

--- a/lib/features/statistics/presentation/screens/statistics_screen.dart
+++ b/lib/features/statistics/presentation/screens/statistics_screen.dart
@@ -9,6 +9,7 @@ import 'package:aboapp/widgets/empty_state_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class StatisticsScreen extends StatefulWidget {
   const StatisticsScreen({super.key});
@@ -39,16 +40,16 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                 const Center(child: CircularProgressIndicator.adaptive()),
             empty: (message) => EmptyStateWidget(
               icon: Icons.insights_rounded,
-              title: 'No Statistics Yet',
+              title: context.l10n.translate('stats_empty_title'),
               message: message,
             ),
             error: (message) => EmptyStateWidget(
               icon: Icons.error_outline_rounded,
-              title: 'Error Loading Statistics',
+              title: context.l10n.translate('stats_error_title'),
               message: message,
               onRetry: () =>
                   context.read<StatisticsCubit>().generateStatistics(),
-              retryText: 'Retry',
+              retryText: context.l10n.translate('retry'),
             ),
             loaded: (
               activeSubscriptions,
@@ -93,7 +94,7 @@ class _StatisticsScreenState extends State<StatisticsScreen> {
                   child: CustomScrollView(
                     slivers: <Widget>[
                       SliverAppBar(
-                        title: const Text('Statistics'),
+                        title: Text(context.l10n.translate('stats_title')),
                         floating: true,
                         snap: true,
                         actions: [

--- a/lib/features/statistics/presentation/widgets/category_spending_pie_chart_card.dart
+++ b/lib/features/statistics/presentation/widgets/category_spending_pie_chart_card.dart
@@ -5,6 +5,7 @@ import 'package:aboapp/features/subscriptions/presentation/widgets/subscription_
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class CategorySpendingPieChartCard extends StatefulWidget {
   final List<CategorySpending> categorySpendingData;
@@ -34,7 +35,7 @@ class _CategorySpendingPieChartCardState
           padding: const EdgeInsets.all(16.0),
           child: Center(
             child: Text(
-              'No category spending data available.',
+              context.l10n.translate('stats_category_empty_message'),
               style: theme.textTheme.bodyMedium,
             ),
           ),
@@ -50,7 +51,7 @@ class _CategorySpendingPieChartCardState
           padding: const EdgeInsets.all(16.0),
           child: Center(
             child: Text(
-              'No significant category spending.',
+              context.l10n.translate('stats_category_empty_significant_message'),
               style: theme.textTheme.bodyMedium,
             ),
           ),
@@ -65,7 +66,7 @@ class _CategorySpendingPieChartCardState
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Spending by Category',
+              context.l10n.translate('stats_category_spending_title'),
               style: theme.textTheme.titleMedium
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),

--- a/lib/features/statistics/presentation/widgets/spending_trend_line_chart_card.dart
+++ b/lib/features/statistics/presentation/widgets/spending_trend_line_chart_card.dart
@@ -5,6 +5,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class SpendingTrendLineChartCard extends StatelessWidget {
   final MonthlySpendingTrendData spendingTrendData;
@@ -25,7 +26,10 @@ class SpendingTrendLineChartCard extends StatelessWidget {
           padding: const EdgeInsets.all(16.0),
           child: Center(
             child: Text(
-              'No spending trend data available for ${spendingTrendData.year}.',
+              context.l10n.translate(
+                'stats_spending_trend_empty_message',
+                args: {'year': spendingTrendData.year.toString()},
+              ),
               style: theme.textTheme.bodyMedium,
             ),
           ),
@@ -40,7 +44,10 @@ class SpendingTrendLineChartCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Spending Trend - ${spendingTrendData.year}',
+              context.l10n.translate(
+                'stats_spending_trend_title',
+                args: {'year': spendingTrendData.year.toString()},
+              ),
               style: theme.textTheme.titleMedium
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),

--- a/lib/features/subscriptions/presentation/screens/home_screen.dart
+++ b/lib/features/subscriptions/presentation/screens/home_screen.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:aboapp/core/utils/haptic_feedback.dart' as app_haptics;
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -82,7 +83,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                 focusNode: _searchFocusNode,
                                 autofocus: true,
                                 decoration: InputDecoration(
-                                    hintText: 'Search subscriptions...',
+                                    hintText: context.l10n.translate('home_search_subscriptions_hint'),
                                     border: InputBorder.none,
                                     isDense: true,
                                     hintStyle: theme.appBarTheme.titleTextStyle
@@ -95,7 +96,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                     .read<SubscriptionCubit>()
                                     .searchSubscriptions(query),
                               )
-                            : const Text('My Subscriptions'),
+                            : Text(context.l10n.translate('home_my_subscriptions')),
                       ),
                       actions: [
                         if (!_isSearching)
@@ -120,14 +121,16 @@ class _HomeScreenState extends State<HomeScreen> {
                                 },
                               );
                             },
-                            tooltip: 'Filter & Sort',
+                            tooltip: context.l10n.translate('home_filter_sort_tooltip'),
                           ),
                         IconButton(
                           icon: Icon(_isSearching
                               ? Icons.close_rounded
                               : Icons.search_rounded),
                           onPressed: () => _toggleSearch(context),
-                          tooltip: _isSearching ? 'Close Search' : 'Search',
+                          tooltip: _isSearching
+                              ? context.l10n.translate('home_close_search_tooltip')
+                              : context.l10n.translate('home_search_tooltip'),
                         ),
                       ],
                       floating: true,
@@ -153,12 +156,12 @@ class _HomeScreenState extends State<HomeScreen> {
                         child: Center(
                           child: EmptyStateWidget(
                             icon: Icons.search_off_rounded,
-                            title: 'No Subscriptions Found',
-                            message: 'Try adjusting your search or filters.',
+                            title: context.l10n.translate('home_no_subscriptions_found_title'),
+                            message: context.l10n.translate('home_no_results_message'),
                             onRetry: () => context
                                 .read<SubscriptionCubit>()
                                 .clearAllFilters(),
-                            retryText: 'Clear Filters',
+                            retryText: context.l10n.translate('home_clear_filters_button'),
                           ),
                         ),
                       )
@@ -190,11 +193,11 @@ class _HomeScreenState extends State<HomeScreen> {
             error: (message) => Center(
               child: EmptyStateWidget(
                 icon: Icons.error_outline_rounded,
-                title: 'Error',
+                title: context.l10n.translate('error_occurred'),
                 message: message,
                 onRetry: () =>
                     context.read<SubscriptionCubit>().loadSubscriptions(),
-                retryText: 'Retry',
+                retryText: context.l10n.translate('retry'),
               ),
             ),
           );
@@ -288,7 +291,7 @@ class _HomeScreenState extends State<HomeScreen> {
           children: <Widget>[
             ListTile(
               leading: const Icon(Icons.edit_rounded),
-              title: const Text('Edit Subscription'),
+              title: Text(context.l10n.translate('subscription_action_edit')),
               onTap: () {
                 Navigator.pop(builderContext);
                 context.pushNamed(
@@ -303,8 +306,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   ? Icons.pause_circle_outline_rounded
                   : Icons.play_circle_outline_rounded),
               title: Text(subscription.isActive
-                  ? 'Pause Subscription'
-                  : 'Resume Subscription'),
+                  ? context.l10n.translate('subscription_action_pause')
+                  : context.l10n.translate('subscription_action_resume')),
               onTap: () {
                 Navigator.pop(builderContext);
                 context
@@ -317,8 +320,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   ? Icons.notifications_off_rounded
                   : Icons.notifications_active_rounded),
               title: Text(subscription.notificationsEnabled
-                  ? 'Disable Notifications'
-                  : 'Enable Notifications'),
+                  ? context.l10n.translate('subscription_action_disable_notifications')
+                  : context.l10n.translate('subscription_action_enable_notifications')),
               onTap: () {
                 Navigator.pop(builderContext);
                 context
@@ -329,24 +332,33 @@ class _HomeScreenState extends State<HomeScreen> {
             ListTile(
               leading: Icon(Icons.delete_forever_rounded,
                   color: theme.colorScheme.error),
-              title: Text('Delete Subscription',
-                  style: TextStyle(color: theme.colorScheme.error)),
+              title: Text(
+                context.l10n.translate('subscription_action_delete'),
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
               onTap: () async {
                 Navigator.pop(builderContext);
                 final confirmDelete = await showDialog<bool>(
                   context: context,
                   builder: (dialogContext) => AlertDialog(
-                    title: const Text('Confirm Delete'),
+                    title: Text(context.l10n
+                        .translate('subscription_delete_confirm_title')),
                     content: Text(
-                        'Are you sure you want to delete "${subscription.name}"? This cannot be undone.'),
+                      context.l10n.translate(
+                        'subscription_delete_confirm_message',
+                        args: {'name': subscription.name},
+                      ),
+                    ),
                     actions: <Widget>[
                       TextButton(
-                        child: const Text('Cancel'),
+                        child: Text(context.l10n.translate('cancel')),
                         onPressed: () => Navigator.of(dialogContext).pop(false),
                       ),
                       TextButton(
-                        child: Text('Delete',
-                            style: TextStyle(color: theme.colorScheme.error)),
+                        child: Text(
+                          context.l10n.translate('delete'),
+                          style: TextStyle(color: theme.colorScheme.error),
+                        ),
                         onPressed: () => Navigator.of(dialogContext).pop(true),
                       ),
                     ],

--- a/lib/main_container_screen.dart
+++ b/lib/main_container_screen.dart
@@ -138,7 +138,7 @@ class _MainContainerScreenState extends State<MainContainerScreen> {
                 index: 2),
             _buildBottomNavItem(
                 icon: Icons.person_rounded,
-                label: 'Profile',
+                label: context.l10n.translate('bottom_nav_profile'),
                 index: 3), // Example for future use
           ],
         ),

--- a/lib/widgets/empty_state_widget.dart
+++ b/lib/widgets/empty_state_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class EmptyStateWidget extends StatelessWidget {
   final IconData icon;
@@ -51,7 +52,8 @@ class EmptyStateWidget extends StatelessWidget {
               const SizedBox(height: 24),
               ElevatedButton.icon(
                 icon: const Icon(Icons.refresh_rounded),
-                label: Text(retryText ?? 'Try Again'), 
+                label:
+                    Text(retryText ?? context.l10n.translate('retry')),
                 onPressed: onRetry,
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),


### PR DESCRIPTION
## Summary
- add translation keys for missing UI strings
- use `context.l10n.translate()` for home, settings, stats, onboarding and more
- show translations for dialogs and page titles

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862530583348324a8c339f7bc00d2a2