### PR TITLE
Add keystore instructions and conditional signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,31 @@ Unterstützte Plattformen: Android, iOS, Web und Desktop (Windows, macOS, Linux)
 ## Weitere Informationen
 - [Datenschutzerklärung](PRIVACY_POLICY.md)
 - [Taskliste](Tasklist.md)
+
+## Android Signing
+Um eine signierte Android-App zu bauen, muss ein Keystore erstellt und die Zugangsdaten in einer Datei `key.properties` hinterlegt werden. Dies ist optional und wird nur verwendet, wenn `key.properties` vorhanden ist.
+
+### Keystore erstellen
+Führe im Projektverzeichnis folgendes Kommando aus:
+
+```bash
+keytool -genkeypair -v \
+  -keystore upload-keystore.jks \
+  -keyalg RSA -keysize 2048 \
+  -validity 10000 \
+  -alias upload
+```
+
+Lege das erzeugte `upload-keystore.jks` zum Beispiel im Ordner `android/` ab.
+
+### key.properties anlegen
+Erstelle anschließend eine Datei `key.properties` im Projektstamm mit folgendem Inhalt und passe die Werte an dein Keystore an:
+
+```properties
+storePassword=<store-passwort>
+keyPassword=<key-passwort>
+keyAlias=upload
+storeFile=android/upload-keystore.jks
+```
+
+Beim Build liest Gradle diese Datei automatisch ein und verwendet die Angaben zum Signieren des Release-Builds.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,17 +15,20 @@ android {
     // Key-Properties laden
     val keyProperties = Properties()
     val keyPropertiesFile = rootProject.file("key.properties")
-    if (keyPropertiesFile.exists()) {
+    val hasKeyProperties = keyPropertiesFile.exists()
+    if (hasKeyProperties) {
         keyProperties.load(FileInputStream(keyPropertiesFile))
     }
 
     signingConfigs {
-        create("release") {
-            keyAlias = keyProperties["keyAlias"] as String?
-            keyPassword = keyProperties["keyPassword"] as String?
-            // Sicherere Zuweisung für die storeFile
-            storeFile = if (keyProperties["storeFile"] != null) file(keyProperties["storeFile"] as String) else null
-            storePassword = keyProperties["storePassword"] as String?
+        if (hasKeyProperties) {
+            create("release") {
+                keyAlias = keyProperties["keyAlias"] as String?
+                keyPassword = keyProperties["keyPassword"] as String?
+                // Sicherere Zuweisung für die storeFile
+                storeFile = if (keyProperties["storeFile"] != null) file(keyProperties["storeFile"] as String) else null
+                storePassword = keyProperties["storePassword"] as String?
+            }
         }
     }
 
@@ -48,12 +51,14 @@ android {
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            if (hasKeyProperties) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             isMinifyEnabled = true
             isShrinkResources = true
             getDefaultProguardFile("proguard-android-optimize.txt")
 
-            
+
         }
     }
 }


### PR DESCRIPTION
## Summary
- document how to create a keystore and key.properties
- only load signing config if `key.properties` exists

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6864edb146548324a5fefcc101fc95b9