### PR TITLE
Add cubit and widget tests

### DIFF
--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:aboapp/features/subscriptions/presentation/cubit/subscription_cubit.dart';
+import 'package:aboapp/features/subscriptions/presentation/screens/home_screen.dart';
+import 'package:aboapp/features/subscriptions/domain/entities/subscription_entity.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/add_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/delete_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/get_all_subscriptions_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/update_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/repositories/subscription_repository.dart';
+import 'package:aboapp/features/settings/presentation/cubit/settings_cubit.dart';
+import 'package:aboapp/features/settings/domain/entities/settings_entity.dart';
+import 'package:aboapp/features/settings/domain/repositories/settings_repository.dart';
+import 'package:aboapp/features/settings/domain/usecases/get_settings_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_theme_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_locale_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_currency_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_salary_settings_usecase.dart';
+import 'package:aboapp/core/localization/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:uuid/uuid.dart';
+
+class FakeSubscriptionRepository implements SubscriptionRepository {
+  List<SubscriptionEntity> subs;
+  FakeSubscriptionRepository({required this.subs});
+
+  @override
+  Future<void> addSubscription(SubscriptionEntity subscription) async {
+    subs.add(subscription);
+  }
+
+  @override
+  Future<void> deleteSubscription(String id) async {
+    subs.removeWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<List<SubscriptionEntity>> getAllSubscriptions() async => List.from(subs);
+
+  @override
+  Future<SubscriptionEntity?> getSubscriptionById(String id) async {
+    try {
+      return subs.firstWhere((s) => s.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveAllSubscriptions(List<SubscriptionEntity> subscriptions) async {
+    subs = subscriptions;
+  }
+
+  @override
+  Future<void> updateSubscription(SubscriptionEntity subscription) async {
+    final index = subs.indexWhere((s) => s.id == subscription.id);
+    if (index != -1) {
+      subs[index] = subscription;
+    } else {
+      subs.add(subscription);
+    }
+  }
+}
+
+class FakeSettingsRepository implements SettingsRepository {
+  SettingsEntity settings;
+  FakeSettingsRepository({required this.settings});
+
+  @override
+  Future<SettingsEntity> getSettings() async => settings;
+
+  @override
+  Future<void> saveThemeMode(ThemeMode themeMode) async {}
+
+  @override
+  Future<void> saveLocale(Locale locale) async {}
+
+  @override
+  Future<void> saveCurrencyCode(String currencyCode) async {}
+
+  @override
+  Future<void> saveSalarySettings({
+    required double? salary,
+    required SalaryCycle salaryCycle,
+    required bool hasThirteenthSalary,
+  }) async {}
+}
+
+void main() {
+  testWidgets('HomeScreen shows subscription list', (tester) async {
+    final repo = FakeSubscriptionRepository(subs: [
+      SubscriptionEntity(
+        id: '1',
+        name: 'Test',
+        price: 10,
+        billingCycle: BillingCycle.monthly,
+        nextBillingDate: DateTime(2025, 1, 1),
+        category: SubscriptionCategory.streaming,
+      ),
+    ]);
+    final subscriptionCubit = SubscriptionCubit(
+      GetAllSubscriptionsUseCase(repo),
+      AddSubscriptionUseCase(repo),
+      UpdateSubscriptionUseCase(repo),
+      DeleteSubscriptionUseCase(repo),
+      const Uuid(),
+    );
+    subscriptionCubit.emit(SubscriptionState.loaded(
+      allSubscriptions: repo.subs,
+      filteredSubscriptions: repo.subs,
+      currentSortOption: SortOption.nextBillingDateAsc,
+      filterCategories: const [],
+      filterBillingCycles: const [],
+      searchTerm: null,
+    ));
+
+    final settingsCubit = SettingsCubit(
+      GetSettingsUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveThemeSettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveLocaleSettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveCurrencySettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveSalarySettingsUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+    );
+
+    settingsCubit.emit(settingsCubit.state.copyWith(isLoading: false));
+
+    await tester.pumpWidget(MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: subscriptionCubit),
+        BlocProvider.value(value: settingsCubit),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US')],
+        home: const HomeScreen(),
+      ),
+    ));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test'), findsOneWidget);
+  });
+}

--- a/test/statistics_cubit_test.dart
+++ b/test/statistics_cubit_test.dart
@@ -1,0 +1,250 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:aboapp/features/settings/domain/entities/settings_entity.dart';
+import 'package:aboapp/features/settings/domain/repositories/settings_repository.dart';
+import 'package:aboapp/features/settings/domain/usecases/get_settings_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_theme_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_locale_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_currency_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_salary_settings_usecase.dart';
+import 'package:aboapp/features/settings/presentation/cubit/settings_cubit.dart';
+import 'package:aboapp/features/subscriptions/domain/repositories/subscription_repository.dart';
+import 'package:aboapp/features/subscriptions/domain/entities/subscription_entity.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/get_all_subscriptions_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/add_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/update_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/delete_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/presentation/cubit/subscription_cubit.dart';
+import 'package:aboapp/features/statistics/presentation/cubit/statistics_cubit.dart';
+import 'package:uuid/uuid.dart';
+
+class FakeSubscriptionRepository implements SubscriptionRepository {
+  List<SubscriptionEntity> subs;
+  FakeSubscriptionRepository({required this.subs});
+
+  @override
+  Future<void> addSubscription(SubscriptionEntity subscription) async {
+    subs.add(subscription);
+  }
+
+  @override
+  Future<void> deleteSubscription(String id) async {
+    subs.removeWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<List<SubscriptionEntity>> getAllSubscriptions() async => List.from(subs);
+
+  @override
+  Future<SubscriptionEntity?> getSubscriptionById(String id) async {
+    try {
+      return subs.firstWhere((s) => s.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveAllSubscriptions(List<SubscriptionEntity> subscriptions) async {
+    subs = subscriptions;
+  }
+
+  @override
+  Future<void> updateSubscription(SubscriptionEntity subscription) async {
+    final index = subs.indexWhere((s) => s.id == subscription.id);
+    if (index != -1) {
+      subs[index] = subscription;
+    } else {
+      subs.add(subscription);
+    }
+  }
+}
+
+class FakeSettingsRepository implements SettingsRepository {
+  SettingsEntity settings;
+  FakeSettingsRepository({required this.settings});
+
+  @override
+  Future<SettingsEntity> getSettings() async => settings;
+
+  @override
+  Future<void> saveThemeMode(ThemeMode themeMode) async {
+    settings = settings.copyWith(themeMode: themeMode);
+  }
+
+  @override
+  Future<void> saveLocale(Locale locale) async {
+    settings = settings.copyWith(locale: locale);
+  }
+
+  @override
+  Future<void> saveCurrencyCode(String currencyCode) async {
+    settings = settings.copyWith(currencyCode: currencyCode);
+  }
+
+  @override
+  Future<void> saveSalarySettings({
+    required double? salary,
+    required SalaryCycle salaryCycle,
+    required bool hasThirteenthSalary,
+  }) async {
+    settings = settings.copyWith(
+      salary: salary,
+      salaryCycle: salaryCycle,
+      hasThirteenthSalary: hasThirteenthSalary,
+    );
+  }
+}
+
+void main() {
+  group('StatisticsCubit', () {
+    late SubscriptionCubit subscriptionCubit;
+    late SettingsCubit settingsCubit;
+    late StatisticsCubit statisticsCubit;
+
+    setUp(() {
+      final subRepo = FakeSubscriptionRepository(subs: []);
+      subscriptionCubit = SubscriptionCubit(
+        GetAllSubscriptionsUseCase(subRepo),
+        AddSubscriptionUseCase(subRepo),
+        UpdateSubscriptionUseCase(subRepo),
+        DeleteSubscriptionUseCase(subRepo),
+        const Uuid(),
+      );
+
+      final settingsRepo = FakeSettingsRepository(
+        settings: const SettingsEntity(
+          themeMode: ThemeMode.system,
+          locale: Locale('en', 'US'),
+          currencyCode: 'USD',
+          salary: 1200,
+          salaryCycle: SalaryCycle.monthly,
+          hasThirteenthSalary: true,
+        ),
+      );
+      settingsCubit = SettingsCubit(
+        GetSettingsUseCase(settingsRepo),
+        SaveThemeSettingUseCase(settingsRepo),
+        SaveLocaleSettingUseCase(settingsRepo),
+        SaveCurrencySettingUseCase(settingsRepo),
+        SaveSalarySettingsUseCase(settingsRepo),
+      );
+    });
+
+    test('generateStatistics emits empty when no active subscriptions', () {
+      subscriptionCubit.emit(const SubscriptionState.loaded(
+        allSubscriptions: [],
+        filteredSubscriptions: [],
+        currentSortOption: SortOption.nextBillingDateAsc,
+        filterCategories: [],
+        filterBillingCycles: [],
+        searchTerm: null,
+      ));
+      settingsCubit.emit(settingsCubit.state.copyWith(
+        salary: 1200,
+        salaryCycle: SalaryCycle.monthly,
+        hasThirteenthSalary: true,
+        isLoading: false,
+      ));
+
+      statisticsCubit = StatisticsCubit(
+        subscriptionCubit: subscriptionCubit,
+        settingsCubit: settingsCubit,
+      );
+
+      statisticsCubit.generateStatistics();
+
+      statisticsCubit.state.maybeWhen(
+        empty: (msg) => expect(msg, isNotEmpty),
+        orElse: () => fail('State should be empty'),
+      );
+    });
+
+    test('generateStatistics computes totals from active subscriptions', () {
+      final sub1 = SubscriptionEntity(
+        id: '1',
+        name: 'A',
+        price: 10,
+        billingCycle: BillingCycle.monthly,
+        nextBillingDate: DateTime(2025, 1, 1),
+        category: SubscriptionCategory.streaming,
+      );
+      final sub2 = SubscriptionEntity(
+        id: '2',
+        name: 'B',
+        price: 120,
+        billingCycle: BillingCycle.yearly,
+        nextBillingDate: DateTime(2025, 2, 1),
+        category: SubscriptionCategory.software,
+      );
+
+      subscriptionCubit.emit(SubscriptionState.loaded(
+        allSubscriptions: [sub1, sub2],
+        filteredSubscriptions: [sub1, sub2],
+        currentSortOption: SortOption.nextBillingDateAsc,
+        filterCategories: [],
+        filterBillingCycles: [],
+        searchTerm: null,
+      ));
+      settingsCubit.emit(settingsCubit.state.copyWith(
+        salary: 1200,
+        salaryCycle: SalaryCycle.monthly,
+        hasThirteenthSalary: true,
+        isLoading: false,
+      ));
+
+      statisticsCubit = StatisticsCubit(
+        subscriptionCubit: subscriptionCubit,
+        settingsCubit: settingsCubit,
+      );
+
+      statisticsCubit.generateStatistics();
+
+      statisticsCubit.state.maybeWhen(
+        loaded: (
+          active,
+          category,
+          billing,
+          top,
+          trend,
+          monthly,
+          yearly,
+          selectedYear,
+          salary,
+          percent,
+        ) {
+          expect(active.length, 2);
+          expect(monthly, closeTo(20, 0.001));
+          expect(yearly, closeTo(240, 0.001));
+          expect(percent, isNotNull);
+        },
+        orElse: () => fail('State should be loaded'),
+      );
+    });
+
+    test('changeTrendYear updates selected year', () {
+      subscriptionCubit.emit(const SubscriptionState.loaded(
+        allSubscriptions: [],
+        filteredSubscriptions: [],
+        currentSortOption: SortOption.nextBillingDateAsc,
+        filterCategories: [],
+        filterBillingCycles: [],
+        searchTerm: null,
+      ));
+      settingsCubit.emit(settingsCubit.state.copyWith(
+        salary: 1200,
+        salaryCycle: SalaryCycle.monthly,
+        hasThirteenthSalary: true,
+        isLoading: false,
+      ));
+      statisticsCubit = StatisticsCubit(
+        subscriptionCubit: subscriptionCubit,
+        settingsCubit: settingsCubit,
+      );
+
+      statisticsCubit.generateStatistics();
+
+      expect(() => statisticsCubit.changeTrendYear(2023), returnsNormally);
+    });
+  });
+}

--- a/test/statistics_screen_test.dart
+++ b/test/statistics_screen_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:aboapp/features/statistics/presentation/screens/statistics_screen.dart';
+import 'package:aboapp/features/statistics/presentation/cubit/statistics_cubit.dart';
+import 'package:aboapp/features/subscriptions/presentation/cubit/subscription_cubit.dart';
+import 'package:aboapp/features/subscriptions/domain/entities/subscription_entity.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/add_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/delete_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/get_all_subscriptions_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/update_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/repositories/subscription_repository.dart';
+import 'package:aboapp/features/settings/presentation/cubit/settings_cubit.dart';
+import 'package:aboapp/features/settings/domain/entities/settings_entity.dart';
+import 'package:aboapp/features/settings/domain/repositories/settings_repository.dart';
+import 'package:aboapp/features/settings/domain/usecases/get_settings_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_theme_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_locale_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_currency_setting_usecase.dart';
+import 'package:aboapp/features/settings/domain/usecases/save_salary_settings_usecase.dart';
+import 'package:aboapp/core/localization/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:uuid/uuid.dart';
+
+class FakeSubscriptionRepository implements SubscriptionRepository {
+  List<SubscriptionEntity> subs;
+  FakeSubscriptionRepository({required this.subs});
+
+  @override
+  Future<void> addSubscription(SubscriptionEntity subscription) async {
+    subs.add(subscription);
+  }
+
+  @override
+  Future<void> deleteSubscription(String id) async {
+    subs.removeWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<List<SubscriptionEntity>> getAllSubscriptions() async => List.from(subs);
+
+  @override
+  Future<SubscriptionEntity?> getSubscriptionById(String id) async {
+    try {
+      return subs.firstWhere((s) => s.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveAllSubscriptions(List<SubscriptionEntity> subscriptions) async {
+    subs = subscriptions;
+  }
+
+  @override
+  Future<void> updateSubscription(SubscriptionEntity subscription) async {
+    final index = subs.indexWhere((s) => s.id == subscription.id);
+    if (index != -1) {
+      subs[index] = subscription;
+    } else {
+      subs.add(subscription);
+    }
+  }
+}
+
+class FakeSettingsRepository implements SettingsRepository {
+  SettingsEntity settings;
+  FakeSettingsRepository({required this.settings});
+
+  @override
+  Future<SettingsEntity> getSettings() async => settings;
+
+  @override
+  Future<void> saveThemeMode(ThemeMode themeMode) async {}
+
+  @override
+  Future<void> saveLocale(Locale locale) async {}
+
+  @override
+  Future<void> saveCurrencyCode(String currencyCode) async {}
+
+  @override
+  Future<void> saveSalarySettings({
+    required double? salary,
+    required SalaryCycle salaryCycle,
+    required bool hasThirteenthSalary,
+  }) async {}
+}
+
+void main() {
+  testWidgets('StatisticsScreen displays stats data', (tester) async {
+    final subRepo = FakeSubscriptionRepository(subs: [
+      SubscriptionEntity(
+        id: '1',
+        name: 'A',
+        price: 10,
+        billingCycle: BillingCycle.monthly,
+        nextBillingDate: DateTime(2025, 1, 1),
+        category: SubscriptionCategory.streaming,
+      ),
+    ]);
+    final subscriptionCubit = SubscriptionCubit(
+      GetAllSubscriptionsUseCase(subRepo),
+      AddSubscriptionUseCase(subRepo),
+      UpdateSubscriptionUseCase(subRepo),
+      DeleteSubscriptionUseCase(subRepo),
+      const Uuid(),
+    );
+    subscriptionCubit.emit(SubscriptionState.loaded(
+      allSubscriptions: subRepo.subs,
+      filteredSubscriptions: subRepo.subs,
+      currentSortOption: SortOption.nextBillingDateAsc,
+      filterCategories: const [],
+      filterBillingCycles: const [],
+      searchTerm: null,
+    ));
+
+    final settingsCubit = SettingsCubit(
+      GetSettingsUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveThemeSettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveLocaleSettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveCurrencySettingUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+      SaveSalarySettingsUseCase(FakeSettingsRepository(
+          settings: const SettingsEntity(
+        themeMode: ThemeMode.system,
+        locale: Locale('en', 'US'),
+        currencyCode: 'USD',
+      ))),
+    );
+    settingsCubit.emit(settingsCubit.state.copyWith(isLoading: false));
+
+    final statisticsCubit = StatisticsCubit(
+      subscriptionCubit: subscriptionCubit,
+      settingsCubit: settingsCubit,
+    );
+    statisticsCubit.generateStatistics();
+
+    await tester.pumpWidget(MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: subscriptionCubit),
+        BlocProvider.value(value: settingsCubit),
+        BlocProvider.value(value: statisticsCubit),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: const [
+          AppLocalizations.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', 'US')],
+        home: const StatisticsScreen(),
+      ),
+    ));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Statistics'), findsOneWidget);
+  });
+}

--- a/test/subscription_cubit_test.dart
+++ b/test/subscription_cubit_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:aboapp/features/subscriptions/presentation/cubit/subscription_cubit.dart';
+import 'package:aboapp/features/subscriptions/domain/repositories/subscription_repository.dart';
+import 'package:aboapp/features/subscriptions/domain/entities/subscription_entity.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/get_all_subscriptions_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/add_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/update_subscription_usecase.dart';
+import 'package:aboapp/features/subscriptions/domain/usecases/delete_subscription_usecase.dart';
+import 'package:uuid/uuid.dart';
+
+class FakeSubscriptionRepository implements SubscriptionRepository {
+  List<SubscriptionEntity> subs;
+  FakeSubscriptionRepository({required this.subs});
+
+  @override
+  Future<void> addSubscription(SubscriptionEntity subscription) async {
+    subs.add(subscription);
+  }
+
+  @override
+  Future<void> deleteSubscription(String id) async {
+    subs.removeWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<List<SubscriptionEntity>> getAllSubscriptions() async => List.from(subs);
+
+  @override
+  Future<SubscriptionEntity?> getSubscriptionById(String id) async {
+    try {
+      return subs.firstWhere((s) => s.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveAllSubscriptions(List<SubscriptionEntity> subscriptions) async {
+    subs = subscriptions;
+  }
+
+  @override
+  Future<void> updateSubscription(SubscriptionEntity subscription) async {
+    final index = subs.indexWhere((s) => s.id == subscription.id);
+    if (index != -1) {
+      subs[index] = subscription;
+    } else {
+      subs.add(subscription);
+    }
+  }
+}
+
+void main() {
+  group('SubscriptionCubit', () {
+    late FakeSubscriptionRepository repository;
+    late SubscriptionCubit cubit;
+    late SubscriptionEntity subA;
+    late SubscriptionEntity subB;
+
+    setUp(() {
+      subA = SubscriptionEntity(
+        id: 'a',
+        name: 'A',
+        price: 10,
+        billingCycle: BillingCycle.monthly,
+        nextBillingDate: DateTime(2025, 1, 1),
+        category: SubscriptionCategory.streaming,
+      );
+      subB = SubscriptionEntity(
+        id: 'b',
+        name: 'B',
+        price: 5,
+        billingCycle: BillingCycle.yearly,
+        nextBillingDate: DateTime(2024, 12, 1),
+        category: SubscriptionCategory.software,
+        isActive: false,
+      );
+      repository = FakeSubscriptionRepository(subs: [subA, subB]);
+      cubit = SubscriptionCubit(
+        GetAllSubscriptionsUseCase(repository),
+        AddSubscriptionUseCase(repository),
+        UpdateSubscriptionUseCase(repository),
+        DeleteSubscriptionUseCase(repository),
+        const Uuid(),
+      );
+    });
+
+    test('loadSubscriptions loads and sorts subscriptions', () async {
+      await cubit.loadSubscriptions();
+
+      cubit.state.maybeWhen(
+        loaded: (all, filtered, sort, cats, bills, search) {
+          expect(all.length, 2);
+          expect(filtered.first.id, 'b'); // earliest nextBillingDate comes first
+          expect(sort, SortOption.nextBillingDateAsc);
+        },
+        orElse: () => fail('State should be loaded'),
+      );
+    });
+
+    test('addSubscription adds to list', () async {
+      await cubit.loadSubscriptions();
+      final newSub = subA.copyWith(id: '', name: 'C');
+      await cubit.addSubscription(newSub);
+
+      cubit.state.maybeWhen(
+        loaded: (all, filtered, sort, cats, bills, search) {
+          expect(all.length, 3);
+          expect(all.any((s) => s.name == 'C'), isTrue);
+        },
+        orElse: () => fail('State should be loaded'),
+      );
+      expect(repository.subs.length, 3);
+    });
+
+    test('toggleSubscriptionActiveStatus updates subscription', () async {
+      await cubit.loadSubscriptions();
+      await cubit.toggleSubscriptionActiveStatus('a');
+
+      final updated = repository.subs.firstWhere((s) => s.id == 'a');
+      expect(updated.isActive, isFalse);
+      cubit.state.maybeWhen(
+        loaded: (all, filtered, sort, cats, bills, search) {
+          final cubitSub = all.firstWhere((s) => s.id == 'a');
+          expect(cubitSub.isActive, isFalse);
+        },
+        orElse: () => fail('State should be loaded'),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for SubscriptionCubit and StatisticsCubit
- write widget tests for HomeScreen and StatisticsScreen
- ensure workflow runs tests

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6864edb2cdd0832483ddce8cf20411db