### PR TITLE
Localize statistics strings

### DIFF
--- a/assets/l10n/de.json
+++ b/assets/l10n/de.json
@@ -149,6 +149,8 @@
   "stats_per_month_label": "pro Monat",
   "stats_subscription_abbrev_single": "Abo",
   "stats_subscription_abbrev_multiple": "Abos",
+  "stats_salary_contribution_title": "Gehaltsanteil",
+  "stats_salary_contribution_message": "Du gibst {percentage}% deines Jahresgehalts ({salary}) für Abos aus.",
   "bottom_nav_profile": "Profil",
   "home_filter_sort_tooltip": "Filtern & Sortieren",
   "home_no_subscriptions_found_title": "Keine Abos gefunden",
@@ -164,5 +166,6 @@
   "settings_salary_13th_checkbox": "Ich erhalte einen 13. Monatslohn",
   "onboarding_salary_optional_title": "Optional: Gehaltsinformationen",
   "onboarding_salary_optional_desc": "Gib dein Gehalt ein, um zu sehen, welcher Anteil für Abos ausgegeben wird. Diese Angabe ist optional und wird nur auf deinem Gerät gespeichert.",
+  "onboarding_salary_hint": "z.B. 5000",
   "page_not_found_title": "Seite nicht gefunden"
 }

--- a/assets/l10n/en.json
+++ b/assets/l10n/en.json
@@ -149,6 +149,8 @@
   "stats_per_month_label": "per month",
   "stats_subscription_abbrev_single": "sub",
   "stats_subscription_abbrev_multiple": "subs",
+  "stats_salary_contribution_title": "Salary Contribution",
+  "stats_salary_contribution_message": "You're spending {percentage}% of your yearly salary ({salary}) on subscriptions.",
   "onboarding_page1_title": "Welcome to AboApp!",
   "onboarding_page1_desc": "Track your subscriptions and save money effortlessly.",
   "onboarding_page2_title": "Add Subscriptions Easily",
@@ -175,5 +177,6 @@
   "settings_salary_13th_checkbox": "I receive a 13th salary",
   "onboarding_salary_optional_title": "Optional: Salary Insights",
   "onboarding_salary_optional_desc": "Enter your salary to see what percentage of it goes to subscriptions. This is optional and stored only on your device.",
+  "onboarding_salary_hint": "e.g., 5000",
   "page_not_found_title": "Page Not Found"
 }

--- a/lib/features/onboarding/presentation/widgets/salary_onboarding_page.dart
+++ b/lib/features/onboarding/presentation/widgets/salary_onboarding_page.dart
@@ -71,10 +71,11 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
               decoration: InputDecoration(
                 labelText:
                     context.l10n.translate('settings_salary_amount_label'),
-                hintText: "e.g., 5000",
+                hintText: context.l10n.translate('onboarding_salary_hint'),
                 prefixIcon: const Icon(Icons.attach_money_rounded),
               ),
-              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
               inputFormatters: [
                 FilteringTextInputFormatter.allow(RegExp(r'[\d,.]'))
               ],
@@ -84,7 +85,8 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
               segments: [
                 ButtonSegment(
                     value: SalaryCycle.monthly,
-                    label: Text(context.l10n.translate('billing_cycle_monthly')),
+                    label:
+                        Text(context.l10n.translate('billing_cycle_monthly')),
                     icon: Icon(Icons.calendar_view_month)),
                 ButtonSegment(
                     value: SalaryCycle.yearly,
@@ -107,8 +109,8 @@ class SalaryOnboardingPageState extends State<SalaryOnboardingPage> {
             const SizedBox(height: 8),
             if (_salaryCycle == SalaryCycle.monthly)
               SwitchListTile.adaptive(
-                title:
-                    Text(context.l10n.translate('settings_salary_13th_checkbox')),
+                title: Text(
+                    context.l10n.translate('settings_salary_13th_checkbox')),
                 value: _hasThirteenthSalary,
                 onChanged: (value) {
                   app_haptics.HapticFeedback.lightImpact();

--- a/lib/features/statistics/presentation/widgets/overall_spending_summary_card.dart
+++ b/lib/features/statistics/presentation/widgets/overall_spending_summary_card.dart
@@ -3,6 +3,7 @@ import 'package:aboapp/widgets/animated_counter_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class OverallSpendingSummaryCard extends StatelessWidget {
   final double totalMonthlySpending;
@@ -33,7 +34,7 @@ class OverallSpendingSummaryCard extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              'Spending Overview',
+              context.l10n.translate('stats_overall_spending_title'),
               style: theme.textTheme.titleMedium
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),
@@ -43,7 +44,7 @@ class OverallSpendingSummaryCard extends StatelessWidget {
                 _buildMetric(
                   context: context,
                   currencyFormat: currencyFormat,
-                  label: 'Monthly',
+                  label: context.l10n.translate('billing_cycle_monthly'),
                   value: totalMonthlySpending,
                   style: theme.textTheme.headlineMedium!.copyWith(
                     color: theme.colorScheme.primary,
@@ -55,7 +56,7 @@ class OverallSpendingSummaryCard extends StatelessWidget {
                 _buildMetric(
                   context: context,
                   currencyFormat: currencyFormat,
-                  label: 'Yearly',
+                  label: context.l10n.translate('billing_cycle_yearly'),
                   value: totalYearlySpending,
                   style: theme.textTheme.headlineMedium!.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,

--- a/lib/features/statistics/presentation/widgets/salary_insight_card.dart
+++ b/lib/features/statistics/presentation/widgets/salary_insight_card.dart
@@ -4,6 +4,7 @@ import 'package:aboapp/features/settings/presentation/cubit/settings_cubit.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:percent_indicator/percent_indicator.dart';
+import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class SalaryInsightCard extends StatelessWidget {
   final double percentageOfSalary;
@@ -53,13 +54,19 @@ class SalaryInsightCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    "Salary Contribution",
+                    context.l10n.translate('stats_salary_contribution_title'),
                     style: theme.textTheme.titleMedium
                         ?.copyWith(fontWeight: FontWeight.bold),
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    "You're spending $formattedPercentage% of your yearly salary ($formattedSalary) on subscriptions.",
+                    context.l10n.translate(
+                      'stats_salary_contribution_message',
+                      args: {
+                        'percentage': formattedPercentage,
+                        'salary': formattedSalary,
+                      },
+                    ),
                     style: theme.textTheme.bodyMedium
                         ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
                   ),

--- a/lib/features/statistics/presentation/widgets/spending_trend_line_chart_card.dart
+++ b/lib/features/statistics/presentation/widgets/spending_trend_line_chart_card.dart
@@ -93,17 +93,15 @@ class SpendingTrendLineChartCard extends StatelessWidget {
                             reservedSize: 30,
                             interval: 2,
                             getTitlesWidget: (value, meta) {
-                              const months = [
-                                'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                                'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-                              ];
-                              final int monthIndex = value.toInt() - 1;
-                              if (monthIndex >= 0 &&
-                                  monthIndex < months.length) {
+                              final int monthIndex = value.toInt();
+                              if (monthIndex >= 1 && monthIndex <= 12) {
+                                final monthName = DateFormat.MMM(
+                                        settingsState.locale.toLanguageTag())
+                                    .format(DateTime(2020, monthIndex));
                                 return SideTitleWidget(
                                   axisSide: meta.axisSide,
                                   space: 8.0,
-                                  child: Text(months[monthIndex],
+                                  child: Text(monthName,
                                       style: theme.textTheme.bodySmall),
                                 );
                               }
@@ -186,14 +184,13 @@ class SpendingTrendLineChartCard extends StatelessWidget {
                         touchTooltipData: LineTouchTooltipData(
                           getTooltipColor: (spot) =>
                               theme.colorScheme.surfaceContainerHighest,
-                          getTooltipItems:
-                              (List<LineBarSpot> touchedBarSpots) {
+                          getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
                             return touchedBarSpots.map((barSpot) {
                               final flSpot = barSpot;
                               final monthName = DateFormat.MMMM(
                                       settingsState.locale.toLanguageTag())
-                                  .format(DateTime(
-                                      spendingTrendData.year, flSpot.x.toInt()));
+                                  .format(DateTime(spendingTrendData.year,
+                                      flSpot.x.toInt()));
                               return LineTooltipItem(
                                 '$monthName: ${CurrencyFormatter.format(flSpot.y, currencyCode: settingsState.currencyCode, locale: settingsState.locale, decimalDigits: 0)}\n',
                                 TextStyle(

--- a/lib/features/subscriptions/presentation/widgets/subscription_card_widget.dart
+++ b/lib/features/subscriptions/presentation/widgets/subscription_card_widget.dart
@@ -64,7 +64,7 @@ class SubscriptionCardWidget extends StatelessWidget {
       daysFutureText:
           '${context.l10n.translate('subscription_card_days_until_label_prefix')} {days} ${context.l10n.translate('subscription_card_days_until_label_suffix')}',
     );
-    
+
     final bool isInactive = !subscription.isActive;
 
     return Card(
@@ -76,7 +76,8 @@ class SubscriptionCardWidget extends StatelessWidget {
         child: Container(
           foregroundDecoration: BoxDecoration(
             color: isInactive
-                ? theme.colorScheme.onSurface.withAlpha(20) // Subtiles graues Overlay
+                ? theme.colorScheme.onSurface
+                    .withAlpha(20) // Subtiles graues Overlay
                 : Colors.transparent,
             borderRadius: BorderRadius.circular(
                 theme.cardTheme.shape is RoundedRectangleBorder
@@ -120,7 +121,8 @@ class SubscriptionCardWidget extends StatelessWidget {
                             borderRadius: BorderRadius.circular(6),
                           ),
                           child: Text(
-                            'TRIAL',
+                            context.l10n
+                                .translate('subscription_card_trial_badge'),
                             style: theme.textTheme.labelSmall?.copyWith(
                               color: theme.colorScheme.onTertiaryContainer,
                               fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- localize the Trial badge on subscription cards
- add new salary insight localization strings in JSON and use them
- internationalize salary hint on onboarding page
- translate labels in OverallSpendingSummaryCard
- generate month names dynamically

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6864edb390d883249ff2bb05bcee5831