### PR TITLE
Fix localization initialization bug

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -35,7 +35,8 @@ class AboApp extends StatelessWidget {
       child: BlocBuilder<SettingsCubit, SettingsState>(
         builder: (context, settingsState) {
           return MaterialApp.router(
-            title: context.l10n.translate('app_title'),
+            onGenerateTitle: (context) =>
+                context.l10n.translate('app_title'),
             debugShowCheckedModeBanner: false,
             // VEREINFACHT: Wir verwenden jetzt immer das AppTheme.
             theme: AppTheme.lightTheme,


### PR DESCRIPTION
## Summary
- fix crash when building MaterialApp before localization is available by using `onGenerateTitle`

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686532f5d2808324b4cef7a3d636f6f8