### PR TITLE
Fix suggestions screen navigation

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -46,7 +46,10 @@ class AppRouter {
         ),
         ShellRoute(
           builder: (context, state, child) {
-            return MainContainerScreen(location: state.uri.toString());
+            return MainContainerScreen(
+              location: state.uri.toString(),
+              child: child,
+            );
           },
           routes: [
             GoRoute(

--- a/lib/main_container_screen.dart
+++ b/lib/main_container_screen.dart
@@ -15,7 +15,8 @@ import 'package:aboapp/core/localization/l10n_extensions.dart';
 
 class MainContainerScreen extends StatefulWidget {
   final String location;
-  const MainContainerScreen({super.key, required this.location});
+  final Widget child;
+  const MainContainerScreen({super.key, required this.location, required this.child});
 
   @override
   State<MainContainerScreen> createState() => _MainContainerScreenState();
@@ -96,20 +97,25 @@ class _MainContainerScreenState extends State<MainContainerScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: PageView(
-        controller: _pageController,
-        onPageChanged: _onPageChanged,
-        physics: const BouncingScrollPhysics(),
-        children: <Widget>[
-          const HomeScreen(),
-          BlocProvider(
-            create: (context) => StatisticsCubit(
-              subscriptionCubit: context.read<SubscriptionCubit>(),
-              settingsCubit: context.read<SettingsCubit>(),
-            ),
-            child: const StatisticsScreen(),
+      body: Stack(
+        children: [
+          PageView(
+            controller: _pageController,
+            onPageChanged: _onPageChanged,
+            physics: const BouncingScrollPhysics(),
+            children: <Widget>[
+              const HomeScreen(),
+              BlocProvider(
+                create: (context) => StatisticsCubit(
+                  subscriptionCubit: context.read<SubscriptionCubit>(),
+                  settingsCubit: context.read<SettingsCubit>(),
+                ),
+                child: const StatisticsScreen(),
+              ),
+              const SettingsScreen(),
+            ],
           ),
-          const SettingsScreen(),
+          widget.child,
         ],
       ),
       floatingActionButton: FloatingActionButton(


### PR DESCRIPTION
## Summary
- show email suggestions screen overlay inside main container
- pass route child to main container

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686534efe0fc83249c48eb376d317afa